### PR TITLE
[BUG] Content collection warning and date of posts

### DIFF
--- a/src/components/FormattedDate.astro
+++ b/src/components/FormattedDate.astro
@@ -6,10 +6,7 @@ interface Props {
 
 const { date, lang } = Astro.props;
 
-let locale = 'es-mx'
-if (lang == 'en') {
-	locale = 'en-us'
-}
+let locale = lang == 'es' ? 'es-mx' : 'en-us'
 ---
 
 <time datetime={date.toISOString()}>
@@ -17,8 +14,7 @@ if (lang == 'en') {
 		date.toLocaleDateString(locale, {
 			year: 'numeric',
 			month: 'short',
-			day: 'numeric',
-			timeZone: 'UTC'
+			day: 'numeric'
 		})
 	}
 </time>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -9,10 +9,10 @@ interface Props {
 
 const { lang } = Astro.props;
 
-const posts = await getCollection("post", ({ data }) => {
+const posts = await getCollection("posts", ({ data }) => {
     return data.lang == lang;
 });
-posts.sort((a, b) => Date.parse(b.data.date) - Date.parse(a.data.date));
+posts.sort((a, b) => Date.parse(b.data.pubDate.toString()) - Date.parse(a.data.pubDate.toString()));
 ---
 
 <nav>
@@ -23,7 +23,7 @@ posts.sort((a, b) => Date.parse(b.data.date) - Date.parse(a.data.date));
                 <hr />
                 <span>
                     <FormattedDate
-                        date={post.data.date}
+                        date={post.data.pubDate}
                         lang={post.data.lang}
                     />
                 </span>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -3,7 +3,8 @@ import { defineCollection, z } from "astro:content";
 const posts = defineCollection({
     schema: z.object({
         title: z.string().max(50),
-        date: z.date(),
+        author: z.string().max(20),
+        pubDate: z.date(),
         lang: z.string().max(2),
         description: z.string()
     })

--- a/src/content/posts/en/special-match.mdx
+++ b/src/content/posts/en/special-match.mdx
@@ -1,9 +1,10 @@
 ---
 title: A special match
-date: 2024-02-18
+author: Martin Morales
+pubDate: 2024-02-19 23:25:00
 lang: en
-description: I had a special volleyball match, I faced to appreciated people, unfortunately the score was not the best for ...
-tags: []
+description: I had a special volleyball match, I faced to appreciated people, unfortunately the score was not the best for...
+tags: [experience]
 ---
 
 Today we had a special volleyball match in tournament, we played against **Evolution** team. I am used to train with them, some players are my friends.I can say that this match is a kind of derby. 

--- a/src/content/posts/en/takeoff.mdx
+++ b/src/content/posts/en/takeoff.mdx
@@ -1,9 +1,10 @@
 ---
 title: Take off 🚀
-date: 2024-02-08
+author: Martin Morales
+pubDate: 2024-02-15 14:38:00
 lang: en
-description: Starting this great adventure. A brief description about my intentions with this blog.
-tags: []
+description: Starting this great adventure where I can share a little bit about me to the world.
+tags: [project]
 ---
 
 I spend some time writing about my thoughts, experiences or anything that catches my attention. I have created a digital garden to house these notes and I enjoy reading them occasionally.

--- a/src/content/posts/special-match.mdx
+++ b/src/content/posts/special-match.mdx
@@ -1,9 +1,10 @@
 ---
 title: Un partido especial
-date: 2024-02-18
+author: Martin Morales
+pubDate: 2024-02-18 23:46:00
 lang: es
 description: Hoy tuve un juego de voleíbol muy especial, me enfrenté con personas que aprecio mucho, lamentablemente el marcador no fue el mejor para...
-tags: []
+tags: [experience]
 ---
 
 El día de hoy tuvimos un partido de voleíbol en el torneo contra el equipo de **Evolución**. En ese equipo juegan varios amigos y con ellos entreno en el parque. Se podría decir que es el _derby de San Jacinto_.

--- a/src/content/posts/takeoff.mdx
+++ b/src/content/posts/takeoff.mdx
@@ -1,9 +1,10 @@
 ---
 title: Despegue 🚀
-date: 2024-02-08
+author: Martin Morales
+pubDate: 2024-02-11 23:26:00
 lang: es
-description: Comenzando esta gran aventura. Una breve descripción sobre este blog.
-tags: []
+description: Comienzo con un nuevo proyecto donde abro un poco de mi vida al mundo.
+tags: [project]
 ---
 
 Llevo algo de tiempo en que suelo escribir cosas que navegan en mi

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -5,7 +5,7 @@ import Layout from "@layouts/Layout.astro";
 import Home from "@components/Home.astro";
 
 export async function getStaticPaths() {
-  const posts = await getCollection("post");
+  const posts = await getCollection("posts");
 
   return posts.map((post) => ({
     params: { slug: post.slug },
@@ -22,6 +22,6 @@ const { Content } = await post.render();
     <Home title={post.data.title} lang={post.data.lang} />
     <Content />
     <br />
-    <p><FormattedDate date={post.data.date} lang={post.data.lang} /></p>
+    <p><FormattedDate date={post.data.pubDate} lang={post.data.lang} /></p>
   </main>
 </Layout>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -5,10 +5,10 @@ import Layout from "@layouts/Layout.astro";
 import { getCollection } from "astro:content"
 import Home from "@components/Home.astro";
 
-const posts = await getCollection("post", ({ data }) => {
+const posts = await getCollection("posts", ({ data }) => {
 	return data.lang == "en"
 });
-posts.sort((a, b) => Date.parse(b.data.date) - Date.parse(a.data.date));
+posts.sort((a, b) => Date.parse(b.data.pubDate.toString()) - Date.parse(a.data.pubDate.toString()));
 
 const latestPost = posts[0];
 const { Content } = await latestPost.render()
@@ -19,6 +19,6 @@ const { Content } = await latestPost.render()
 		<Home title={latestPost.data.title} lang={latestPost.data.lang} />
 		<Content />
 		<br>
-		<p><FormattedDate date={latestPost.data.date} lang={latestPost.data.lang}/></p>
+		<p><FormattedDate date={latestPost.data.pubDate} lang={latestPost.data.lang}/></p>
 	</main>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,10 +4,10 @@ import "@styles/global.css";
 import Layout from "@layouts/Layout.astro";
 import { getCollection } from "astro:content"
 
-const posts = await getCollection("post", ({ data }) => {
+const posts = await getCollection("posts", ({ data }) => {
 	return data.lang == "es"
 });
-posts.sort((a, b) => Date.parse(b.data.date) - Date.parse(a.data.date));
+posts.sort((a, b) => Date.parse(b.data.pubDate.toString()) - Date.parse(a.data.pubDate.toString()));
 
 const latestPost = posts[0];
 const { Content } = await latestPost.render();
@@ -18,6 +18,6 @@ const { Content } = await latestPost.render();
 		<h1><a href="/">{latestPost.data.title}</a></h1>
 		<Content />
 		<br>
-		<p><FormattedDate date={latestPost.data.date} lang={latestPost.data.lang}/></p>
+		<p><FormattedDate date={latestPost.data.pubDate} lang={latestPost.data.lang}/></p>
 	</main>
 </Layout>

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -3,15 +3,16 @@ import { getCollection } from "astro:content";
 
 export async function GET(context) {
 
-    const posts = await getCollection('post');
+    const posts = await getCollection('posts');
 
     return rss({
-        title: 'Martin Morales RSS Feed',
+        title: 'Martin Morales',
         description: 'A small collection of thoughts, experiences and other things.',
         site: context.site,
         items: posts.map((post) => ({
             title: post.data.title,
-            pubDate: post.data.date,
+            author: post.data.author,
+            pubDate: post.data.pubDate,
             link: `/${post.slug}`,
             description: post.body
         })),


### PR DESCRIPTION
## Summary
Fixed date on MDX files and post collection issue

### Publication date in posts
Time was added in MDX files, specifically `pubDate` property. Some changes were included to adapt new property name `pubDate`.
This reformatted property will be used on RSS xml file.

### Content collection warning
The warning: `The posts collection is defined but no content/posts folder exists in the content directory. Create a new folder for the collection, or check your content configuration file for typos.` is fixed. I had to rename `post` folder to `posts` and I did some modifications where content colllection is used.

## Evidence

Please include some screenshot if apply 

|Before|After|
|---|---|
|![image](https://github.com/IsTheMartin/mrtnmrls/assets/38388605/ecf3fdf0-3273-4c12-a6d3-77c58f3d3dd9)|![image](https://github.com/IsTheMartin/mrtnmrls/assets/38388605/be2f1c03-40f8-489f-819c-91867385f9ef)|

## Concern Information

To test please follow the next steps:

1. Navigate `index`
2. Observe post's date and dates in navigation.
3. Click on `RSS`
4. Observe `pubDate` on RSS file

## Issue ticket

- https://github.com/IsTheMartin/mrtnmrls/issues/15
- https://github.com/IsTheMartin/mrtnmrls/issues/19

## Check list

- [ x ] I did add reviewers to this PR