### PR TITLE
Custom page not found

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ import netlify from "@astrojs/netlify";
 export default defineConfig({
   site: "https://mrtnmrls.com",
   integrations: [mdx()],
-  output: "hybrid",
+  output: "server",
   adapter: netlify(),
   i18n: {
     defaultLocale: "es",

--- a/src/layouts/Layout404.astro
+++ b/src/layouts/Layout404.astro
@@ -1,0 +1,23 @@
+---
+interface Props {
+	title: string;
+	lang: string;
+}
+
+const { title, lang } = Astro.props;
+---
+
+<!doctype html>
+<html lang={lang}>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="description" content="Martin' space" />
+		<meta name="viewport" content="width=device-width" />
+		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<meta name="generator" content={Astro.generator} />
+		<title>{title} | Martin</title>
+	</head>
+	<body>
+		<slot />
+	</body>
+</html>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,35 +1,19 @@
 ---
 import "@styles/global.css";
-import Home from "@components/Home.astro";
+import Layout404 from "@layouts/Layout404.astro";
 
-const title = "Page not found"
+const title = "Página no encontrada";
+const lang = "es";
 ---
 
-<!doctype html>
-<html lang="es">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="description" content="Martin' space" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="generator" content={Astro.generator} />
-		<title>{title} | Martin</title>
-	</head>
-	<body>
-        <main>
-        <Home title="Página no encontrada" lang="es" />
-        <p>
-            Parece que no he encontrado esta página en este sitio. Puedes intentar editar la URL pero si no quieres hacerlo te dejo este link a <a href="/">Inicio</a>. Espero no verte tan seguido en esta página.
-            <br>
-            Un consejo: Los títulos te llevan a casa.
-        </p>        
-        <br>
-        <Home title="Page not found" lang="en" />
-        <p>
-            It seems I have not found this page in this site. You can try to edit URL, however if you don't want do it, I let this link to <a href="/en">Home</a>. I hope don't see you again in this page.
-            <br>
-            One tip: Titles take you home
-        </p>
-    </main>
-	</body>
-</html>
+<Layout404 title={title} lang={lang}>
+  <main>
+    <h1><a href="/">Se ha perdido esta página</a></h1>
+    <p>
+      Y no la he localizado, probablemente la url no sea la correcta. Intentar
+      editarla o <a href="/">regresa al inicio.</a>
+    </p>
+    <br />
+    <p>Un tip: los títulos nos llevan a casa.</p>
+  </main>
+</Layout404>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -4,16 +4,13 @@ import { getCollection } from "astro:content";
 import Layout from "@layouts/Layout.astro";
 import Home from "@components/Home.astro";
 
-export async function getStaticPaths() {
-  const posts = await getCollection("posts");
+const { slug } = Astro.params;
+const posts = await getCollection("posts");
+const post = posts.find((post) => post.slug === slug);
 
-  return posts.map((post) => ({
-    params: { slug: post.slug },
-    props: { post },
-  }));
-}
+const redirectPage = slug.includes("en/") ? "/en/404" : "/404";
+if (!post) return Astro.redirect(redirectPage);
 
-const { post } = Astro.props;
 const { Content } = await post.render();
 ---
 

--- a/src/pages/en/404.astro
+++ b/src/pages/en/404.astro
@@ -1,0 +1,19 @@
+---
+import "@styles/global.css";
+import Layout404 from "@layouts/Layout404.astro";
+
+const title = "Page not found";
+const lang = "en";
+---
+
+<Layout404 title={title} lang={lang}>
+  <main>
+    <h1><a href="/en">This page is missing</a></h1>
+    <p>
+      And I do not found it, maybe url is wrong. Try to edit it or <a href="/en"
+        >go back home.</a>
+    </p>
+    <br />
+    <p>One tip: titles take us to home.</p>
+  </main>
+</Layout404>


### PR DESCRIPTION
## Summary
Implemented routing for 404 pages

When a page was not found in site, a 404 page was being displayed without format. Reading more about what is happening, I figured out that site needs a routing logic for 404 pages.

I added a specific layout for 404 pages without footer. Then I created a new 404 page for english speakers. Finally I modified slug template to add a code logic when a page was not found, this logic redirects to 404 page based on slug.

Important thing: I changed output property in configuration file to generate page from server.
## Evidence

|Before|After|
|---|---|
|<img width="1425" alt="image" src="https://github.com/IsTheMartin/mrtnmrls/assets/38388605/ed6ab4bb-7546-44b9-8080-463e140b03b6">|<img width="1023" alt="image" src="https://github.com/IsTheMartin/mrtnmrls/assets/38388605/743552b7-d320-4e97-b6b1-6d06276ca81e">|

## Concern Information

To test please follow the next steps:

1. Navigate to not-existing page
2. Observe content

## Issue ticket

- https://github.com/IsTheMartin/mrtnmrls/issues/29

## Check list

- [ x ] I did add reviewers to this PR